### PR TITLE
Fix (?) the Deploy Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A sample [Next.js] project for getting started with [MDX] & [Theme UI].
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/git?s=https%3A%2F%2Fgithub.com%2Flachlanjc%2Fnext-theme-starter&repo-name=next-theme-project)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Flachlanjc%2Fnext-theme-starter&repository-name=next-theme-starter)
 
 [next.js]: https://nextjs.org
 [mdx]: https://mdxjs.com


### PR DESCRIPTION
It seems that the deploy button isn't working for me, leading to:

<img width="1438" alt="Screenshot 2021-03-07 at 11 17 46 AM" src="https://user-images.githubusercontent.com/39828164/110227784-bfeeec80-7f36-11eb-94a5-c0e509efdbb6.png">

This PR uses a link that works for me, not sure about your side